### PR TITLE
previene el spoofing de dominios en validación de enlaces + agrega dominios relevantes en el validador

### DIFF
--- a/src/components/ModalLink.jsx
+++ b/src/components/ModalLink.jsx
@@ -15,6 +15,7 @@ function validateLink(link) {
         'imgur.com',
         'drive.google.com',
         'github.com',
+        'gitlab.com',
         'dm.uba.ar',
         'df.uba.ar'
     ];

--- a/src/components/ModalLink.jsx
+++ b/src/components/ModalLink.jsx
@@ -153,7 +153,7 @@ export default function ModalLink({
                         </select>
                     </label>
                 </div>
-                Los links pueden ser de drive, imgur, github, o pags de la facultad.
+                Los links pueden ser de drive, imgur, github, gitlab, o pags de la facultad.
                 <br/>
                 Pasar en el nombre cuatrimestre y año del examen.
                 <br/>

--- a/src/components/ModalLink.jsx
+++ b/src/components/ModalLink.jsx
@@ -16,6 +16,7 @@ function validateLink(link) {
         'drive.google.com',
         'github.com',
         'gitlab.com',
+        'git.exactas.uba.ar',
         'dm.uba.ar',
         'df.uba.ar'
     ];

--- a/src/components/ModalLink.jsx
+++ b/src/components/ModalLink.jsx
@@ -10,6 +10,7 @@ const axiosResueltos = axios.create({
 
 function validateLink(link) {
     const validDomains = [
+        'campus12-24.exactas.uba.ar',
         'campus.exactas.uba.ar',
         'imgur.com',
         'drive.google.com',

--- a/src/components/ModalLink.jsx
+++ b/src/components/ModalLink.jsx
@@ -70,7 +70,7 @@ export default function ModalLink({
                 )
             ) {
                 alert(
-                    'Link inválido. Tiene que empezar con https:// y ser de drive, github, imgur, páginas del dm, df o del campus.',
+                    'Link inválido. Tiene que empezar con https:// y ser de drive, github, gitlab, git de la facultad, imgur, páginas del dm, df o del campus.',
                 );
                 return;
             }

--- a/src/components/ModalLink.jsx
+++ b/src/components/ModalLink.jsx
@@ -9,10 +9,20 @@ const axiosResueltos = axios.create({
 });
 
 function validateLink(link) {
-    const sources = ['campus.exactas', 'imgur', 'drive.google.com', 'github', 'dm.uba', 'df.uba'];
-    const validSource = sources.some(
-        (source) => link.includes(source) && link.includes('https://'),
-    );
+    const validDomains = [
+        'campus.exactas.uba.ar',
+        'imgur.com',
+        'drive.google.com',
+        'github.com',
+        'dm.uba.ar',
+        'df.uba.ar'
+    ];
+    
+    const createDomainPattern = (domain) => 
+        new RegExp(`^https:\\/\\/([a-zA-Z0-9-]+\\.)*${domain.replace(/\./g, '\\.')}`, 'i');
+    
+    const validDomainPatterns = validDomains.map(createDomainPattern);
+    const validSource = validDomainPatterns.some(pattern => pattern.test(link));
     const properLength = link.length < 340;
 
     return validSource && properLength;


### PR DESCRIPTION
La implementación actual de [`validateLink`](https://github.com/pmemoli/Machete-Exactas-Front/blob/c3b2ed347b58b8c02fc14e199c102bd9019d5982/src/components/ModalLink.jsx#L11) utiliza `includes` para verificar si una URL pertenece a una fuente confiable, lo mismo ocurre para la comprobación de `https://`. Esto permite a un atacante spoofear dominios válidos mediante subdominios o poner esos nombres en el path, lo mismo ocurre para `https://`.

**PoC:**
Un atacante podría usar una URL como `https://github.atacante.com/...`, `https://atacante.com/github/...` o `http://atacante.com/...?...&x=https://github` y pasar la validación, ya que la función solo chequea que el string contenga `"github"` y `"https://"`.

Este merge request reemplaza esa lógica por una validación basada en expresiones regulares que asegura coincidencia exacta con los dominios válidos definidos, y sigue permitiendo subdominios de los mismos.

Además, se ampliaron los dominios permitidos para incluir nuevas fuentes relevantes como `gitlab.com`, `git.exactas.uba.ar` y el campus viejo de la facultad, que aún contiene material relevante. Se podría aprovechar la validación por regex que implementa en este merge request para tomar directamente `"exactas.uba.ar"` como dominio válido, pero tampoco me parece mal segregar por subdominios de la facultad, y así forzar que los links sean del campus.
